### PR TITLE
Correctly determine resource url when no generateFrontendUrl hook is …

### DIFF
--- a/src/Resources/contao/ls_apiController.php
+++ b/src/Resources/contao/ls_apiController.php
@@ -317,10 +317,12 @@ class ls_apiController extends \Controller {
 			if (isset($GLOBALS['TL_HOOKS']['generateFrontendUrl'])) {
                 $arr_tmp_generateFrontendUrlHooks = $GLOBALS['TL_HOOKS']['generateFrontendUrl'];
                 $GLOBALS['TL_HOOKS']['generateFrontendUrl'] = array();
+            }
 
-                $str_resourceUrl = $this->generateFrontendUrl($this->arr_pageData, '/resource/'.$str_resourceName);
-                $str_resourceUrl = $this->Environment->base.$str_resourceUrl;
+            $str_resourceUrl = $this->generateFrontendUrl($this->arr_pageData, '/resource/'.$str_resourceName);
+            $str_resourceUrl = $this->Environment->base.$str_resourceUrl;
 
+            if (isset($GLOBALS['TL_HOOKS']['generateFrontendUrl'])) {
                 $GLOBALS['TL_HOOKS']['generateFrontendUrl'] = $arr_tmp_generateFrontendUrlHooks;
                 unset($arr_tmp_generateFrontendUrlHooks);
             }


### PR DESCRIPTION
…registered